### PR TITLE
Reusing tags logic with `git_tags` action

### DIFF
--- a/lib/fastlane/plugin/changelog_generator/actions/fetch_github_labels_action.rb
+++ b/lib/fastlane/plugin/changelog_generator/actions/fetch_github_labels_action.rb
@@ -12,6 +12,7 @@ module Fastlane
         labels = lane_context[SharedValues::GENERATE_CHANGELOG_GITHUB_LABELS]
         pull_requests = lane_context[SharedValues::GENERATE_CHANGELOG_GITHUB_PULL_REQUESTS]
         if labels && pull_requests
+          UI.important "Skipping API call because labels & pull requests are cached"
           return labels, pull_requests
         end
 

--- a/lib/fastlane/plugin/changelog_generator/actions/generate_changelog_action.rb
+++ b/lib/fastlane/plugin/changelog_generator/actions/generate_changelog_action.rb
@@ -7,7 +7,7 @@ module Fastlane
                                                                  github_api_token: params[:github_api_token])
 
         tag_limit = params[:max_number_of_tags]
-        tags = other_action.git_tags(limit: tag_limit)
+        tags = params[:tags] || other_action.git_tags(limit: tag_limit)
         releases = []
 
         # Unreleased section
@@ -17,16 +17,15 @@ module Fastlane
         end
 
         # Between tags sections
-        previous_tag = nil
-        tags.each do |tag|
-          if previous_tag
+        tags.each_with_index do |tag, idx|
+          if idx != 0
+            previous_tag = tags[idx-1]
             releases << Helper::ChangelogGeneratorRelease.new(labels, pull_requests, previous_tag, tag)
           end
-          previous_tag = tag
         end
 
         # Last section
-        if tags.count > 0 && (tag_limit.nil? || tags.count < tag_limit)
+        if tags.count > 0 && params[:tags].nil? && (tag_limit.nil? || tags.count < tag_limit)
           releases << Helper::ChangelogGeneratorRelease.new(labels, pull_requests, nil, tags.last)
         end
 
@@ -64,6 +63,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :template_path,
                                        env_name: 'GENERATE_CHANGELOG_TEMPLATE_PATH',
                                        description: 'Contents of path will override `template` param',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :tags,
+                                       env_name: 'GENERATE_CHANGELOG_TAGS',
+                                       description: 'Tags to generate changelog',
+                                       is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :max_number_of_tags,
                                        env_name: 'GENERATE_CHANGELOG_MAX_NUMBER_OF_TAGS',

--- a/lib/fastlane/plugin/changelog_generator/actions/generate_changelog_action.rb
+++ b/lib/fastlane/plugin/changelog_generator/actions/generate_changelog_action.rb
@@ -19,7 +19,7 @@ module Fastlane
         # Between tags sections
         tags.each_with_index do |tag, idx|
           if idx != 0
-            previous_tag = tags[idx-1]
+            previous_tag = tags[idx - 1]
             releases << Helper::ChangelogGeneratorRelease.new(labels, pull_requests, previous_tag, tag)
           end
         end

--- a/lib/fastlane/plugin/changelog_generator/actions/generate_changelog_action.rb
+++ b/lib/fastlane/plugin/changelog_generator/actions/generate_changelog_action.rb
@@ -7,7 +7,7 @@ module Fastlane
                                                                  github_api_token: params[:github_api_token])
 
         tag_limit = params[:max_number_of_tags]
-        tags = git_tags(tag_limit)
+        tags = other_action.git_tags(limit: tag_limit)
         releases = []
 
         # Unreleased section
@@ -31,12 +31,6 @@ module Fastlane
         end
 
         Helper::ChangelogGeneratorRender.new(releases, labels, params).to_markdown
-      end
-
-      def self.git_tags(limit)
-        tags = `git tag --sort=taggerdate`.split("\n").reverse
-        tags = tags.take(limit) if limit
-        tags
       end
 
       def self.description

--- a/lib/fastlane/plugin/changelog_generator/actions/generate_release_changelog_action.rb
+++ b/lib/fastlane/plugin/changelog_generator/actions/generate_release_changelog_action.rb
@@ -19,7 +19,7 @@ module Fastlane
       def self.prompt_tag(message = '', excluded_tags = [], allow_none = false)
         no_tag_text = 'No tag'
 
-        available_tags = `git tag --sort=taggerdate`.split("\n").reverse.first(10)
+        available_tags = other_action.git_tags(limit: 10)
         available_tags.reject! { |tag| excluded_tags.include?(tag) }
         available_tags << no_tag_text if allow_none
 

--- a/lib/fastlane/plugin/changelog_generator/actions/git_tags_action.rb
+++ b/lib/fastlane/plugin/changelog_generator/actions/git_tags_action.rb
@@ -1,0 +1,37 @@
+module Fastlane
+  module Actions
+    class GitTagsAction < Action
+      def self.run(params)
+        tags = `git tag --sort=taggerdate`.split("\n").reverse
+        tags = tags.take(params[:limit]) if params[:limit]
+        tags
+      end
+
+      def self.description
+        "Git tags sorted by taggerdate"
+      end
+
+      def self.authors
+        ["Fernando Saragoca"]
+      end
+
+      def self.return_value
+        "Array of git tags sorted by taggerdate"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :limit,
+                                       env_name: 'GIT_TAGS_LIMIT',
+                                       description: 'Limit number of tags to return',
+                                       is_string: false,
+                                       optional: true)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/changelog_generator/helper/changelog_generator_release.rb
+++ b/lib/fastlane/plugin/changelog_generator/helper/changelog_generator_release.rb
@@ -44,7 +44,18 @@ module Fastlane
       private
 
       def date_for_commit_with_tag(tag)
-        Time.parse(`git show -s --format=%ci $(git rev-list -n 1 #{tag})`.strip) if tag
+        # Return nil if no tag is provided
+        return nil if tag.nil?
+
+        # Return Time.now if tag is not found (new tag)
+        return Time.now if `git tag | grep #{tag}`.strip.length == 0
+
+        commit_for_tag = `git rev-list -n 1 #{tag}`.strip
+        # Return Time.now if commit for tag not found (new tag)
+        return Time.now if commit_for_tag.length == 0
+
+        # Return parsed date from tag commit
+        Time.parse(`git show -s --format=%ci #{commit_for_tag}`.strip)
       end
     end
   end


### PR DESCRIPTION
- New `git_tag` action
- New `tags` parameter for `generate_changelog` action